### PR TITLE
3rd-party BOM, no dep versions in project

### DIFF
--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -11,10 +11,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.terracotta.forge</groupId>
-    <artifactId>forge-parent</artifactId>
-    <version>4.17</version>
-    <relativePath/>
+    <groupId>net.sf.ehcache</groupId>
+    <artifactId>ehcache-root</artifactId>
+    <version>2.10.10-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>net.sf.ehcache.examples</groupId>
@@ -27,7 +27,6 @@
   <properties>
     <terracotta.version>4.3.10-SNAPSHOT</terracotta.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.39.v20210325</jetty.version>
   </properties>
 
   <build>
@@ -55,7 +54,6 @@
 
       <plugin>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty.version}</version>
         <groupId>org.eclipse.jetty</groupId>
         <configuration>
           <webApp>
@@ -95,13 +93,12 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.25</version>
     </dependency>
   </dependencies>
 
@@ -112,7 +109,6 @@
         <plugins>
           <plugin>
             <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
             <groupId>org.eclipse.jetty</groupId>
             <configuration>
               <systemProperties>
@@ -133,7 +129,6 @@
         <plugins>
           <plugin>
             <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
             <groupId>org.eclipse.jetty</groupId>
             <configuration>
               <systemProperties>

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -4,12 +4,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.terracotta.forge</groupId>
-    <artifactId>forge-parent</artifactId>
-    <version>4.17</version>
-    <relativePath/>
+    <groupId>net.sf.ehcache</groupId>
+    <artifactId>ehcache-root</artifactId>
+    <version>2.10.10-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
-  
+
   <groupId>net.sf.ehcache.examples</groupId>
   <artifactId>events</artifactId>
   <version>2.10.10-SNAPSHOT</version>
@@ -19,10 +19,8 @@
 
   <properties>
     <terracotta.version>4.3.10-SNAPSHOT</terracotta.version>
-    <h2.version>1.1.116</h2.version>
     <exec-maven-plugin.version>1.1</exec-maven-plugin.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.39.v20210325</jetty.version>
   </properties>
 
   <dependencies>
@@ -30,24 +28,20 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.25</version>
     </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
     </dependency>
 
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.19.0-GA</version>
     </dependency>
 
     <dependency>
       <artifactId>h2</artifactId>
-      <version>${h2.version}</version>
       <groupId>com.h2database</groupId>
     </dependency>
 
@@ -66,12 +60,11 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>3.3.1.GA</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -82,11 +75,11 @@
           <artifactId>jta</artifactId>
         </exclusion>
       </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>gf-3122</groupId>
       <artifactId>gf.javax.transaction</artifactId>
-      <version>1.1</version>
     </dependency>
   </dependencies>
 
@@ -117,7 +110,6 @@
       
       <plugin>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>${jetty.version}</version>
         <groupId>org.eclipse.jetty</groupId>
         <configuration>
           <webApp>
@@ -144,7 +136,6 @@
           <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -208,7 +199,6 @@
         <plugins>
           <plugin>
             <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
             <groupId>org.eclipse.jetty</groupId>
             <configuration>
               <systemProperties>
@@ -229,7 +219,6 @@
         <plugins>
           <plugin>
             <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
             <groupId>org.eclipse.jetty</groupId>
             <configuration>
               <systemProperties>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -191,7 +191,12 @@
           </execution>
         </executions>            
       </plugin>
-      <!-- package lib folder, use this plugin to get proper SNAPSHOT file name --> 
+      <!-- look up slf4j.version -->
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+      </plugin>
+      <!-- package lib folder, use this plugin to get proper SNAPSHOT file name -->
       <plugin>
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>

--- a/ehcache-core/checkstyle/checkstyle.xml
+++ b/ehcache-core/checkstyle/checkstyle.xml
@@ -32,6 +32,11 @@
     <property name="format" value="import org\.apache\.commons\.logging\.Log;"/>
   </module>
 
+  <!-- cannot be in TreeWalker any longer: https://github.com/checkstyle/eclipse-cs/issues/190 -->
+  <module name="LineLength">
+    <property name="max" value="150"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- javadoc -->
     <module name="JavadocType">
@@ -70,9 +75,7 @@
     </module>
 
     <!-- Size Violations -->
-    <module name="LineLength">
-      <property name="max" value="150"/>
-    </module>
+
     <module name="MethodLength">
       <property name="max" value="200"/>
       <property name="tokens" value="METHOD_DEF"/>

--- a/ehcache-core/pom.xml
+++ b/ehcache-core/pom.xml
@@ -44,40 +44,49 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>jta</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>sizeof-agent</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Test scope -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.btm</groupId>
       <artifactId>btm</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.hibernate</groupId>
       <artifactId>hibernate</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -88,34 +97,48 @@
           <groupId>org.hamcrest</groupId>
         </exclusion>
       </exclusions>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-ehcache</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>ehcache</artifactId>
+          <groupId>net.sf.ehcache</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xsom</groupId>
       <artifactId>xsom</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.beanshell</groupId>
       <artifactId>bsh</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/ehcache-core/pom.xml
+++ b/ehcache-core/pom.xml
@@ -223,22 +223,10 @@
             </configuration>
           </execution>
           <execution>
-            <id>integration-test-execution</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
+            <id>default-integration-test</id>
             <configuration>
               <skip>${checkshort}</skip> <!-- don't run these when check-short profile is on -->
               <failIfNoTests>false</failIfNoTests>
-              <excludes>
-                <exclude>**/*$*</exclude>
-              </excludes>
-              <includes>
-               <include>**/IT*.java</include>
-               <include>**/*IT.java</include>
-               <include>**/*ITCase.java</include>
-              </includes>
               <argLine>${tests.supplemental.args} -Xms512m -Xmx512m</argLine>
             </configuration>
           </execution>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>org.codehaus.btm</groupId>
       <artifactId>btm</artifactId>
-      <version>2.1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -86,6 +85,19 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- this is only here to resolve the version number in gmavenplus plugin, used by javadoc below -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -195,6 +207,11 @@
       </activation>
       <build>
         <plugins>
+          <!-- look up hibernate-core.version -->
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>

--- a/management-ehcache-impl/ehcache-rest-agent/pom.xml
+++ b/management-ehcache-impl/ehcache-rest-agent/pom.xml
@@ -20,7 +20,6 @@
     <private-class-suffix>.class_terracotta</private-class-suffix>
     <devmode>true</devmode>
     <sag-deps>false</sag-deps>
-    <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
   </properties>
 
   <dependencies>
@@ -37,7 +36,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -47,7 +45,6 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>${jaxb-runtime.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/management-ehcache-impl/management-ehcache-common/pom.xml
+++ b/management-ehcache-impl/management-ehcache-common/pom.xml
@@ -27,6 +27,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/management-ehcache-impl/management-ehcache-impl-v1/pom.xml
+++ b/management-ehcache-impl/management-ehcache-impl-v1/pom.xml
@@ -40,6 +40,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/management-ehcache-impl/management-ehcache-impl-v2/pom.xml
+++ b/management-ehcache-impl/management-ehcache-impl-v2/pom.xml
@@ -87,13 +87,11 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,18 +20,13 @@
   </scm>
   
   <properties>
-    <slf4j.version>1.7.25</slf4j.version>
-    <sizeof-agent.version>1.0.1</sizeof-agent.version>
+    <thirdparty-bom.version>4.3.10-SNAPSHOT</thirdparty-bom.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
     <management-core.version>2.1.27</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>
-    <jetty.version>9.4.39.v20210325</jetty.version>
-    <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
-    <hibernate-core.version>3.5.1-Final</hibernate-core.version>
-    <commons-logging.version>1.2</commons-logging.version>
     <skipJavadoc>false</skipJavadoc>
   </properties>
 
@@ -48,12 +43,14 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Required dependencies -->
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <groupId>org.terracotta</groupId>
+        <artifactId>thirdparty-bom-4.x</artifactId>
+        <version>${thirdparty-bom.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
+      <!-- Required dependencies -->
       <dependency>
         <groupId>org.terracotta.internal</groupId>
         <artifactId>statistics</artifactId>
@@ -68,17 +65,6 @@
         <groupId>com.terracotta</groupId>
         <artifactId>clustered-entity-management</artifactId>
         <version>${clustered-entity-management.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
 <!--
@@ -96,144 +82,13 @@
         <version>${terracotta-toolkit-api-internal.version}</version>
         <scope>provided</scope>
       </dependency>
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>3.1.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>${hibernate-core.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>javax.transaction</groupId>
-        <artifactId>jta</artifactId>
-        <version>1.1</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>sizeof-agent</artifactId>
-        <version>${sizeof-agent.version}</version>
-        <scope>provided</scope>
-      </dependency>
 
       <!-- Test dependencies -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.btm</groupId>
-        <artifactId>btm</artifactId>
-        <version>2.1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.hibernate</groupId>
-        <artifactId>hibernate</artifactId>
-        <version>2.1.8</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>2.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>hamcrest-core</artifactId>
-            <groupId>org.hamcrest</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>dom4j</groupId>
-        <artifactId>dom4j</artifactId>
-        <version>1.6.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.javassist</groupId>
-        <artifactId>javassist</artifactId>
-        <version>3.19.0-GA</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-ehcache</artifactId>
-        <version>3.3.2.GA</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>ehcache</artifactId>
-            <groupId>net.sf.ehcache</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derby</artifactId>
-        <version>10.5.3.0_1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>3.0.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xsom</groupId>
-        <artifactId>xsom</artifactId>
-        <version>20100725</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.beanshell</groupId>
-        <artifactId>bsh</artifactId>
-        <version>1.3.0</version>
-        <scope>test</scope>
-      </dependency>
+
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz</artifactId>
         <version>${quartz.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>4.0.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-easymock</artifactId>
-        <version>2.0.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.2</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -314,6 +169,51 @@
           <artifactId>rmic-maven-plugin</artifactId>
           <version>1.3</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.12.1</version>
+          <executions>
+            <!--
+            Determine some dependency versions so we don't have to duplicate the BOM.
+            BOM only provides a dependencyManagement section, but some plugins need
+            to specify dependency details in their configuration.
+
+            This will work for any project that declares these dependencies
+            (when the dependency is not declared, the property value is '')
+            -->
+            <execution>
+              <id>determine-dep-version</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>execute</goal>
+              </goals>
+              <configuration>
+                <scripts>
+                  <script><![CDATA[
+                    def find = {artifactId ->
+                      project.artifacts.find{it.artifactId == artifactId}?.version ?: ''
+                    }
+                    def props = [
+                            'slf4j.version'           : find('slf4j-api'),
+                            'hibernate-core.version'  : find('hibernate-core')
+                    ]
+                    println "Resolved dependency versions: ${props}"
+                    project.properties.putAll(props)
+                    ]]></script>
+                </scripts>
+              </configuration>
+            </execution>
+          </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-all</artifactId>
+              <version>2.4.17</version>
+              <scope>runtime</scope>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -340,7 +240,8 @@
             </goals>
           </execution>
         </executions>
-      </plugin>    
+      </plugin>
+
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>net.sf.ehcache</groupId>
     <artifactId>ehcache-parent</artifactId>
-    <version>2.27</version>
+    <version>3.0</version>
     <relativePath/>
   </parent>
 
@@ -23,7 +23,7 @@
     <thirdparty-bom.version>4.3.10-SNAPSHOT</thirdparty-bom.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
-    <management-core.version>2.1.27</management-core.version>
+    <management-core.version>2.1.29</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>
@@ -231,13 +231,6 @@
               <generateBuildInfoFile>true</generateBuildInfoFile>
               <buildInfoLocation>${project.build.outputDirectory}</buildInfoLocation>
             </configuration>
-          </execution>
-          <execution>
-            <id>default-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -26,9 +26,7 @@
     <surefire.max-memory>1024m</surefire.max-memory>
     <surefire.additional-jvm-args>-XX:MaxPermSize=512m</surefire.additional-jvm-args>
     <skipCheckstyle>true</skipCheckstyle>
-    <derby.version>10.10.1.1</derby.version>
     <quartz.version>2.2.3</quartz.version>
-    <slf4j.version>1.7.25</slf4j.version>
     <osgi-test-tool.version>1.9</osgi-test-tool.version>
   </properties>
 
@@ -83,37 +81,31 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.19.0-GA</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbynet</artifactId>
-      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyclient</artifactId>
-      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>jta</artifactId>
-      <version>1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.btm</groupId>
       <artifactId>btm</artifactId>
-      <version>2.1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -38,13 +38,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
* To get around BOM limitations, added `gmavenplus` code that dynamically determines versions that are used in plugin configs.
* How can I check whether all my changes to `<provided>` (moving them across levels since I'm getting rid of a lot of `<dependencyManagement>` content) did not screw anything up?

Azure builds will fail until dso PR is merged (and system-tests-parent is published)