### PR TITLE
Add license headers to system-tests (daggy main)

### DIFF
--- a/system-tests/src/test/java/com/otherclassloader/Client.java
+++ b/system-tests/src/test/java/com/otherclassloader/Client.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package com.otherclassloader;
 

--- a/system-tests/src/test/java/com/otherclassloader/Value.java
+++ b/system-tests/src/test/java/com/otherclassloader/Value.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package com.otherclassloader;
 

--- a/system-tests/src/test/java/net/sf/ehcache/CacheAccessor.java
+++ b/system-tests/src/test/java/net/sf/ehcache/CacheAccessor.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache;
 

--- a/system-tests/src/test/java/net/sf/ehcache/StrongCacheInvalidationTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/StrongCacheInvalidationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache;
 

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/AgentsResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/AgentsResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import io.restassured.http.ContentType;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheConfigsResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheConfigsResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import org.junit.After;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagerConfigsResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagerConfigsResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import io.restassured.http.ContentType;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagerLifecycleAgentResourceRESTTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagerLifecycleAgentResourceRESTTest.java
@@ -1,19 +1,19 @@
 /*
- * Copyright Terracotta, Inc.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *      http://terracotta.org/legal/terracotta-public-license.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package net.sf.ehcache.management.resource.services;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagersResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheManagersResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import io.restassured.http.ContentType;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import static io.restassured.RestAssured.expect;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheStatisticSamplesResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/CacheStatisticSamplesResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import io.restassured.RestAssured;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/ElementsResourceServiceImplTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/ElementsResourceServiceImplTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import io.restassured.RestAssured;

--- a/system-tests/src/test/java/net/sf/ehcache/management/resource/services/ResourceServiceImplITHelper.java
+++ b/system-tests/src/test/java/net/sf/ehcache/management/resource/services/ResourceServiceImplITHelper.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package net.sf.ehcache.management.resource.services;
 
 import com.tc.test.config.builder.OffHeap;

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/EhcacheXATest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/EhcacheXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/EvenCacheLoader.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/EvenCacheLoader.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/EvenCacheLoaderFactory.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/EvenCacheLoaderFactory.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/IncrementingCacheLoader.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/IncrementingCacheLoader.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/OddCacheLoader.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/OddCacheLoader.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/OddCacheLoaderFactory.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/OddCacheLoaderFactory.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/OsgiHibernateTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/OsgiHibernateTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/OsgiScheduledRefreshTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/OsgiScheduledRefreshTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/SimpleOsgiTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/SimpleOsgiTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/osgi/TestScheduledRefreshFactory.java
+++ b/system-tests/src/test/java/net/sf/ehcache/osgi/TestScheduledRefreshFactory.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.osgi;
 

--- a/system-tests/src/test/java/net/sf/ehcache/terracotta/AbstractTerracottaActivePassiveTestBase.java
+++ b/system-tests/src/test/java/net/sf/ehcache/terracotta/AbstractTerracottaActivePassiveTestBase.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.terracotta;
 

--- a/system-tests/src/test/java/net/sf/ehcache/terracotta/BootstrapCacheTest.java
+++ b/system-tests/src/test/java/net/sf/ehcache/terracotta/BootstrapCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.terracotta;
 

--- a/system-tests/src/test/java/net/sf/ehcache/util/DerbyWrapper.java
+++ b/system-tests/src/test/java/net/sf/ehcache/util/DerbyWrapper.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package net.sf.ehcache.util;
 

--- a/system-tests/src/test/java/net/sf/ehcache/util/RetryAssert.java
+++ b/system-tests/src/test/java/net/sf/ehcache/util/RetryAssert.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package net.sf.ehcache.util;
 
 import net.sf.ehcache.Ehcache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractCacheTestBase.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractCacheTestBase.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractWriteBehindAtomicityTestBase.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractWriteBehindAtomicityTestBase.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractWriteBehindClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/AbstractWriteBehindClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/BasicStandaloneCacheAndServerTopologyTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/BasicStandaloneCacheAndServerTopologyTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/BasicStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/BasicStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheConsistencyTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheConsistencyTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheEventEvictionExceptionTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheEventEvictionExceptionTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheEventualConsistencyTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheEventualConsistencyTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheRemovalClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CacheRemovalClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/Client1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/Client1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/Client2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/Client2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/Client3.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/Client3.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/Client4.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/Client4.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientArrayValues1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientArrayValues1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientArrayValues2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientArrayValues2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientBase.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClientBase.java
@@ -1,5 +1,18 @@
 /*
- * [ * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterCacheEventsRejoinEnabledClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterCacheEventsRejoinEnabledClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterCacheEventsRejoinEnabledTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterCacheEventsRejoinEnabledTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import com.tc.test.config.model.TestConfig;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsRejoinEnabledTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsRejoinEnabledTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsRejoinEnabledWatcherClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsRejoinEnabledWatcherClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsWatcherClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusterEventsWatcherClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredCacheRemovalTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredCacheRemovalTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import com.tc.test.config.model.TestConfig;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredEventsRemoteClient1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredEventsRemoteClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredEventsRemoteClient2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ClusteredEventsRemoteClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CompressedCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CompressedCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ConcurrencyValueTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ConcurrencyValueTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CopyOnWriteClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CopyOnWriteClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/CopyOnWriteTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/CopyOnWriteTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/DoubleConfigStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/DoubleConfigStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedConfigNamespaceStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedConfigNamespaceStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedConfigStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedConfigStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedEhcacheJarTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedEhcacheJarTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedEhcacheJarTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/EmbeddedEhcacheJarTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/EventualCacheExplicitLockingTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/EventualCacheExplicitLockingTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerClient1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerClient2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ExpiryListenerTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ExplicitlyUnclusteredStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ExplicitlyUnclusteredStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/GetKeysCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/GetKeysCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/GetKeysClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/GetKeysClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/HttpUrlConfigCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/HttpUrlConfigCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/JmxThreadDumper.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/JmxThreadDumper.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/MemoryStoreEvictionPolicyTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/MemoryStoreEvictionPolicyTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/MixedCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/MixedCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NamelessCacheManagerStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NamelessCacheManagerStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NoTcConfigStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NoTcConfigStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NonHibernateCacheDecorator.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NonHibernateCacheDecorator.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.CacheException;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NonHibernateCacheDecoratorFactory.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NonHibernateCacheDecoratorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Ehcache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NonStopCacheCreationTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NonStopCacheCreationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/NonStopCacheDisposalTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/NonStopCacheDisposalTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventClient1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventClient2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassLoaderEventTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassloaderCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassloaderCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassloaderClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OtherClassloaderClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/OverflowToDiskStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/OverflowToDiskStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/PermStress.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/PermStress.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ReaderClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ReaderClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/SerializedArrayCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/SerializedArrayCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/SharedClientMBeanTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/SharedClientMBeanTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/SimpleThreadInfo.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/SimpleThreadInfo.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/SystemPropTcConfigTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/SystemPropTcConfigTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ThreadIgnore.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ThreadIgnore.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/ThreadLocalTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/ThreadLocalTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/TryLockTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/TryLockTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/UnclusteredClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/UnclusteredClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/UrlConfigStandaloneCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/UrlConfigStandaloneCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/Valueable.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/Valueable.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityStrongTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityStrongTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicitySyncStrongTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicitySyncStrongTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindAtomicityTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindCacheWriter.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/WriteBehindCacheWriter.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests;
 
 import net.sf.ehcache.CacheEntry;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/CacheCoherenceExpressClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/CacheCoherenceExpressClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.coherence;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/CacheCoherenceExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/CacheCoherenceExpressTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/IncoherentNodesTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/IncoherentNodesTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/RestartingL1ExpressClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/RestartingL1ExpressClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/RestartingL1ExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/coherence/RestartingL1ExpressTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/AbstractStandaloneContainerJTATestSetup.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/AbstractStandaloneContainerJTATestSetup.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicContainerJTATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicContainerJTATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicContainerTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicContainerTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicJTATestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicJTATestServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicTestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/BasicTestServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/ContainerTestSetup.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/ContainerTestSetup.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/EARContainerTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/EARContainerTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/MultiAppServerTransactionManagerLookup.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/MultiAppServerTransactionManagerLookup.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.container;
 
 import net.sf.ehcache.transaction.manager.TransactionManagerLookup;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/TwoResourceContainerJTATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/TwoResourceContainerJTATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/TwoResourceJTATestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/TwoResourceJTATestServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/BaseClusteredRegionFactoryTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/BaseClusteredRegionFactoryTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright notice. All
- * rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/BaseClusteredRegionFactoryTestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/BaseClusteredRegionFactoryTestServlet.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Account.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Account.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright notice.  All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 
 public class Account {

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Event.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Event.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2009 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/EventManager.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/EventManager.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2009 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/HolidayCalendar.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/HolidayCalendar.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright notice.  All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Item.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Item.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Person.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/Person.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright notice.  All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 
 import java.util.ArrayList;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/PhoneNumber.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/PhoneNumber.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright notice.  All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 
 import java.io.Serializable;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/UuidItem.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/UuidItem.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/VersionedItem.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/domain/VersionedItem.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EhCacheClusteredHibernateCacheServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EhCacheClusteredHibernateCacheServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EhCacheClusteredHibernateCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EhCacheClusteredHibernateCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EmptySecondLevelCacheEntryServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EmptySecondLevelCacheEntryServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EmptySecondLevelCacheEntryTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/EmptySecondLevelCacheEntryTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright notice. All
- * rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/HibernateUtil.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/HibernateUtil.java
@@ -1,8 +1,19 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 
 import org.hibernate.HibernateException;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/KeyDeserializationSecondLevelCacheEntryTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/KeyDeserializationSecondLevelCacheEntryTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/KeyDeserializationSecondLevelCacheEntryTestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/KeyDeserializationSecondLevelCacheEntryTestServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonEternalSecondLevelCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonEternalSecondLevelCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonEternalSecondLevelCacheTestServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonEternalSecondLevelCacheTestServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonTransactionalCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/NonTransactionalCacheTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright notice. All
- * rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/QueryCacheInvalidationServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/QueryCacheInvalidationServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/QueryCacheInvalidationTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/QueryCacheInvalidationTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) Terracotta, Inc., except as may otherwise be noted in a separate copyright notice. All
- * rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/StaleWritesLeaveCacheConsistentServlet.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/container/hibernate/nontransactional/StaleWritesLeaveCacheConsistentServlet.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.container.hibernate.nontransactional;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/loader/LoaderClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/loader/LoaderClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.loader;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/loader/LoaderTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/loader/LoaderTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.loader;
 
 import net.sf.ehcache.CacheManager;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBean.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBean.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.mbean;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBeanController.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBeanController.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.mbean;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBeanProxy.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/mbean/DSOMBeanProxy.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.mbean;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/AddingCacheLoader.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/AddingCacheLoader.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.scheduledrefresh;
 
 /**

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/AddingCacheLoaderFactory.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/AddingCacheLoaderFactory.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.scheduledrefresh;
 
 import net.sf.ehcache.Ehcache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/ClusteredScheduledRefreshTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/scheduledrefresh/ClusteredScheduledRefreshTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.scheduledrefresh;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/BasicServerMapExpressCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/BasicServerMapExpressCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/BasicServerMapExpressTestHelper.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/BasicServerMapExpressTestHelper.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/CacheSizeTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/CacheSizeTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/Client5.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/Client5.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/Client6.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/Client6.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/EvictionCountingEventListener.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/EvictionCountingEventListener.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/LockGCNotFlushingEntriesTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/LockGCNotFlushingEntriesTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/LockGCNotFlushingEntriesTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/LockGCNotFlushingEntriesTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapCapacityEvictionExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapCapacityEvictionExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapCapacityEvictionExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapCapacityEvictionExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import org.terracotta.ehcache.tests.AbstractCacheTestBase;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTestClient1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTestClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTestClient2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearExpressTestClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearTestHelper.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClearTestHelper.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClientBase.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapClientBase.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTIExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTIExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTIExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTIExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTLExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTLExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTLExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapElementTTLExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityEvictionExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityEvictionExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityEvictionExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityEvictionExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityExpirationExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityExpirationExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityExpirationExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL1CapacityExpirationExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesL1Test.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesL1Test.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import org.terracotta.ehcache.tests.AbstractCacheTestBase;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesL1TestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesL1TestClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1Test.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1Test.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import org.terracotta.ehcache.tests.AbstractCacheTestBase;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1TestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1TestClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.servermap;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1Verifier.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapL2EvictionReachesOneL1Verifier.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapLocalSizeTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapLocalSizeTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTIExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTIExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTIExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTIExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTLExpressTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTLExpressTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTLExpressTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/servermap/ServerMapTTLExpressTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.servermap;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/AbstractBTMCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/AbstractBTMCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/AbstractTxClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/AbstractTxClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.txns;
 
 import org.terracotta.ehcache.tests.ClientBase;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMSimpleTx1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMSimpleTx1.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMSimpleTx2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMSimpleTx2.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMTwoResourceTx1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMTwoResourceTx1.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMTwoResourceTx2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BTMTwoResourceTx2.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BareXAResourceTx.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BareXAResourceTx.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BasicAtomikosXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BasicAtomikosXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BasicBTMXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/BasicBTMXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/CacheWriterBTMTxClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/CacheWriterBTMTxClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/CacheWriterBTMXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/CacheWriterBTMXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/LocalTxClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/LocalTxClient.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.ehcache.tests.txns;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/LocalTxTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/LocalTxTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/MultithreadedCommitRollbackTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/MultithreadedCommitRollbackTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SimpleTx1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SimpleTx1.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SimpleTx2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SimpleTx2.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeAtomikosXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeAtomikosXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeBTMClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeBTMClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeBTMXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeBTMXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/SuspendResumeClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceAtomikosXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceAtomikosXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceBTMXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceBTMXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeAtomikosXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeAtomikosXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeBTMClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeBTMClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeBTMXATest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeBTMXATest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeClient.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceSuspendResumeClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceTx1.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceTx1.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceTx2.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/TwoResourceTx2.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/XAResourceTest.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/txns/XAResourceTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.txns;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransaction.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransaction.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.xa;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransactionManager.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransactionManager.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.xa;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransactionManagerLookup.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyTransactionManagerLookup.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.xa;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyXid.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/DummyXid.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.xa;
 

--- a/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/EhCacheXAResourceExtractor.java
+++ b/system-tests/src/test/java/org/terracotta/ehcache/tests/xa/EhCacheXAResourceExtractor.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.ehcache.tests.xa;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/ToolkitClientAccessor.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/ToolkitClientAccessor.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsBasicSerializationSanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsBasicSerializationSanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.bulkops;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsExplictLockingTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsExplictLockingTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.bulkops;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsGenericSanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/BulkOpsGenericSanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.bulkops;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/DummyObject.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/DummyObject.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.bulkops;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/GetAllNonLiteralTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/bulkops/GetAllNonLiteralTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.bulkops;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/cluster/CacheClusterTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/cluster/CacheClusterTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.cluster;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/cluster/TopologyListenerImpl.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/cluster/TopologyListenerImpl.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.cluster;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/CacheCoherenceTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/CacheCoherenceTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/CacheCoherenceTestL1Client.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/CacheCoherenceTestL1Client.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/GetSizeTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/GetSizeTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NewCASEventualCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NewCASEventualCacheTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.coherence;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NoLocksCreatedEventualTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NoLocksCreatedEventualTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NoLocksCreatedTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/coherence/NoLocksCreatedTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.coherence;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusterTopologyTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusterTopologyTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsAllTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsAllTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsEvictionExpiryTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsEvictionExpiryTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsLocalTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsLocalTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsRemoteTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsRemoteTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsSerializationTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/ClusteredEventsSerializationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/EhcacheTerracottaEventListener.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/EhcacheTerracottaEventListener.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/event/EhcacheTerracottaEventListenerFactory.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/event/EhcacheTerracottaEventListenerFactory.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.event;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Account.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Account.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.hibernate.domain;
 
 public class Account {

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Event.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Event.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/EventManager.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/EventManager.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/HolidayCalendar.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/HolidayCalendar.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Item.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Item.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Person.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/Person.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.hibernate.domain;
 
 import java.util.ArrayList;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/PhoneNumber.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/PhoneNumber.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.hibernate.domain;
 
 import java.io.Serializable;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/UuidItem.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/UuidItem.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/VersionedItem.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/hibernate/domain/VersionedItem.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.hibernate.domain;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMCacheManagerRecreateTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMCacheManagerRecreateTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMDynamicConfigurationTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMDynamicConfigurationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapActivePassiveSanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapActivePassiveSanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapBasicSanityTestApp.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapBasicSanityTestApp.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapReadWriteTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapReadWriteTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapSanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapSanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapWithTTISanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapWithTTISanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapWithTTLSanityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/l1bm/L1BMOnHeapWithTTLSanityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.l1bm;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheDestroyCrashTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheDestroyCrashTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.lifecycle;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheDestroyTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheDestroyTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.lifecycle;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheListingTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheListingTest.java
@@ -1,19 +1,19 @@
 /*
- * Copyright Terracotta, Inc.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *      http://terracotta.org/legal/terracotta-public-license.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.lifecycle;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerDestroyCrashTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerDestroyCrashTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.lifecycle;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerDestroyTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerDestroyTest.java
@@ -1,19 +1,19 @@
 /*
- * Copyright Terracotta, Inc.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *      http://terracotta.org/legal/terracotta-public-license.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.lifecycle;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerListingTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/lifecycle/CacheManagerListingTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.lifecycle;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BasicCacheSyncWriteTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BasicCacheSyncWriteTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BasicCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BasicCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BlockingCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/BlockingCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CacheDisposalEvictionListenerTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CacheDisposalEvictionListenerTest.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.store;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CachePinningFaultInvalidatedEntriesTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CachePinningFaultInvalidatedEntriesTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CacheTierPinningTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CacheTierPinningTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ConcurrentCacheMethodsTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ConcurrentCacheMethodsTest.java
@@ -1,7 +1,19 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.modules.ehcache.store;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CopyOnReadTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/CopyOnReadTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/DCV2ConfigurationChangePropagationTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/DCV2ConfigurationChangePropagationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/DynamicCacheConfigurationTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/DynamicCacheConfigurationTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/EvictionListenerTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/EvictionListenerTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ExpirationListenerTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ExpirationListenerTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/GetKeysSerializedCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/GetKeysSerializedCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/LocalReadsGetKeysTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/LocalReadsGetKeysTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/NoCacheWithMaxBytesLocalDiskTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/NoCacheWithMaxBytesLocalDiskTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PinnedCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PinnedCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PrimitiveClassTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PrimitiveClassTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ProgrammaticCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ProgrammaticCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ProgrammaticConfigTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ProgrammaticConfigTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PutAllCustomTTLTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/PutAllCustomTTLTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SampledStatisticTimerTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SampledStatisticTimerTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SerializedCacheCopyOnReadTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SerializedCacheCopyOnReadTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SerializedCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SerializedCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ServerMapBasicCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/ServerMapBasicCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SimpleVersionTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/SimpleVersionTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/StorageStrategyNotSupportedTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/StorageStrategyNotSupportedTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TTICacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TTICacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TTLCacheTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TTLCacheTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TotalCapacityTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/TotalCapacityTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/store/backend/BulkLoadInternalKeyRepresentationExposedTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/store/backend/BulkLoadInternalKeyRepresentationExposedTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.store.backend;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicDeadBucketWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicDeadBucketWriteBehindTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteBehindTestClient.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteBehindTestClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteThroughTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BasicWriteThroughTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BatchWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/BatchWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CacheSeparationWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CacheSeparationWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CoalescingDeadBucketWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CoalescingDeadBucketWriteBehindTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CoalescingWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/CoalescingWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DaemonThreadsWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DaemonThreadsWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DeadBucketWriteBehindClient.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DeadBucketWriteBehindClient.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DistributionDeadBucketWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/DistributionDeadBucketWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/RemovingCacheWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/RemovingCacheWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationDeadBucketWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationDeadBucketWriteBehindTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindClient1.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.writebehind;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindClient2.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.writebehind;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindTest.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindType.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SerializationWriteBehindType.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SynchronousDeadBucketWriteBehindTest.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/SynchronousDeadBucketWriteBehindTest.java
@@ -1,6 +1,18 @@
 /*
- * All content copyright (c) 2003-2008 Terracotta, Inc., except as may otherwise be noted in a separate copyright
- * notice. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindCacheWriter.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindCacheWriter.java
@@ -1,5 +1,18 @@
 /*
- * All content copyright Terracotta, Inc., unless otherwise indicated. All rights reserved.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
  */
 package org.terracotta.modules.ehcache.writebehind;
 

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindClient1.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindClient1.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.writebehind;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindClient2.java
+++ b/system-tests/src/test/java/org/terracotta/modules/ehcache/writebehind/WriteBehindClient2.java
@@ -1,3 +1,19 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *      http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Terracotta Platform.
+ *
+ * The Initial Developer of the Covered Software is
+ *      Terracotta, Inc., a Software AG company
+ */
 package org.terracotta.modules.ehcache.writebehind;
 
 import net.sf.ehcache.Cache;

--- a/system-tests/tc-config.xml
+++ b/system-tests/tc-config.xml
@@ -1,3 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    The contents of this file are subject to the Terracotta Public License Version
+    2.0 (the "License"); You may not use this file except in compliance with the
+    License. You may obtain a copy of the License at
+
+         http://terracotta.org/legal/terracotta-public-license.
+
+    Software distributed under the License is distributed on an "AS IS" basis,
+    WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+    the specific language governing rights and limitations under the License.
+
+    The Covered Software is Terracotta Platform.
+
+    The Initial Developer of the Covered Software is
+         Terracotta, Inc., a Software AG company
+
+-->
 <tc:tc-config xmlns:tc="http://www.terracotta.org/config">
 </tc:tc-config>


### PR DESCRIPTION
use of system-tests-parent/forge-parent now enables license check.

Able to do this as daggy, so why not