### PR TITLE
Release/2.10.9   probable memory leak.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-/.classpath
-/.project
-/target
-/.settings
-/*.iml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-mavenBuildOSS(
+mavenBuildOSS.legacy4x(
     maven_params  : '-Pfullmode,check-short -Dsag-deps=true -DskipLocalStaging=true',
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+/*
+ * All content copyright Terracotta, Inc., unless otherwise indicated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mavenBuildOSS(
+    maven_params  : '-Pfullmode,check-short -Dsag-deps=true -DskipLocalStaging=true',
+)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,36 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See shared code location for steps and parameters:
+# https://dev.azure.com/TerracottaCI/_git/terracotta
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: terracotta/terracotta
+
+jobs:
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jobName: Linux_Java_8
+      options: -B -Djava.test.version=1.8 -Djava.test.vendor=zulu -Pfullmode,check-short -Dsag-deps=true 
+      mavenGoals: 'clean verify'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jobName: Windows_Java_8
+      options: -B -Djava.test.version=1.8 -Djava.test.vendor=zulu -Pfullmode,check-short -Dsag-deps=true 
+      mavenGoals: 'clean verify'

--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <terracotta.version>4.3.9-SNAPSHOT</terracotta.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jetty.version>9.4.39.v20210325</jetty.version>
     <commons-io.version>2.8.0</commons-io.version>
   </properties>
 

--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -151,25 +151,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <terracotta.version>4.3.9-SNAPSHOT</terracotta.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>9.4.35.v20201120</jetty.version>
   </properties>
 
   <build>

--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -27,7 +27,8 @@
   <properties>
     <terracotta.version>4.3.9-SNAPSHOT</terracotta.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.35.v20201120</jetty.version>
+    <jetty.version>9.4.38.v20210224</jetty.version>
+    <commons-io.version>2.8.0</commons-io.version>
   </properties>
 
   <build>

--- a/distribution/colorcache/pom.xml
+++ b/distribution/colorcache/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.terracotta.forge</groupId>
     <artifactId>forge-parent</artifactId>
-    <version>4.16</version>
+    <version>4.17</version>
     <relativePath/>
   </parent>
 

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.terracotta.forge</groupId>
     <artifactId>forge-parent</artifactId>
-    <version>4.16</version>
+    <version>4.17</version>
     <relativePath/>
   </parent>
   

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -22,7 +22,7 @@
     <h2.version>1.1.116</h2.version>
     <exec-maven-plugin.version>1.1</exec-maven-plugin.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>9.4.35.v20201120</jetty.version>
   </properties>
 
   <dependencies>

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -246,27 +246,5 @@
       </build>
     </profile>
   </profiles>
-  
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>   
-  </pluginRepositories>
 
 </project>

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -22,7 +22,8 @@
     <h2.version>1.1.116</h2.version>
     <exec-maven-plugin.version>1.1</exec-maven-plugin.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.35.v20201120</jetty.version>
+    <jetty.version>9.4.38.v20210224</jetty.version>
+    <commons-io.version>2.8.0</commons-io.version>
   </properties>
 
   <dependencies>
@@ -40,9 +41,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.8.0.GA</version>
+      <version>3.19.0-GA</version>
     </dependency>
 
     <dependency>

--- a/distribution/events/pom.xml
+++ b/distribution/events/pom.xml
@@ -22,7 +22,7 @@
     <h2.version>1.1.116</h2.version>
     <exec-maven-plugin.version>1.1</exec-maven-plugin.version>
     <skipDeploy>true</skipDeploy>
-    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jetty.version>9.4.39.v20210325</jetty.version>
     <commons-io.version>2.8.0</commons-io.version>
   </properties>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -263,36 +263,4 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>evgenyg.artifactoryonline.com</id>
-      <url>http://evgenyg.artifactoryonline.com/evgenyg/repo/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>   
-  </pluginRepositories>
-
 </project>

--- a/ehcache-core/pom.xml
+++ b/ehcache-core/pom.xml
@@ -94,7 +94,7 @@
       <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>
     <dependency>

--- a/ehcache-core/pom.xml
+++ b/ehcache-core/pom.xml
@@ -463,28 +463,6 @@
   <!-- The JBoss repository is only here to satisfy the 'provided' dependency
     on hibernate-core -->
   <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
     <!--For Hibernate. Test only -->
     <repository>
       <id>jboss-releases</id>
@@ -509,29 +487,5 @@
       </snapshots>
     </repository>
   </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
 
 </project>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -387,29 +387,6 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <issueManagement>
     <system>JIRA</system>
     <url>https://jira.terracotta.org/jira/browse/EHC</url>

--- a/management-ehcache-impl/ehcache-rest-agent/pom.xml
+++ b/management-ehcache-impl/ehcache-rest-agent/pom.xml
@@ -200,24 +200,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>    
 </project>

--- a/management-ehcache-impl/management-ehcache-common/pom.xml
+++ b/management-ehcache-impl/management-ehcache-common/pom.xml
@@ -64,24 +64,4 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>    
 </project>

--- a/management-ehcache-impl/management-ehcache-common/src/main/java/net/sf/ehcache/management/service/impl/RemoteAgentEndpointImpl.java
+++ b/management-ehcache-impl/management-ehcache-common/src/main/java/net/sf/ehcache/management/service/impl/RemoteAgentEndpointImpl.java
@@ -56,8 +56,15 @@ public class RemoteAgentEndpointImpl extends AbstractRemoteAgentEndpointImpl imp
         @Override
         public Object invoke(String actionName, Object[] params, String[] signature) throws MBeanException, ReflectionException {
           try {
-            requestClusterUUID.set(clientUUID);
-            return super.invoke(actionName, params, signature);
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+              // because some code in Jersey is using the TCCL to resolve some classes
+              Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+              requestClusterUUID.set(clientUUID);
+              return super.invoke(actionName, params, signature);
+            } finally {
+              Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
           } finally {
             requestClusterUUID.remove();
           }

--- a/management-ehcache-impl/management-ehcache-impl-v1/pom.xml
+++ b/management-ehcache-impl/management-ehcache-impl-v1/pom.xml
@@ -87,24 +87,4 @@
     </plugins>
   </build>
   
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>    
 </project>

--- a/management-ehcache-impl/management-ehcache-impl-v2/pom.xml
+++ b/management-ehcache-impl/management-ehcache-impl-v2/pom.xml
@@ -114,24 +114,4 @@
     </plugins>
   </build>
   
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>    
 </project>

--- a/management-ehcache-impl/pom.xml
+++ b/management-ehcache-impl/pom.xml
@@ -20,24 +20,4 @@
     <module>ehcache-rest-agent</module>
   </modules>
   
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>    
 </project>

--- a/management-ehcache-v1/pom.xml
+++ b/management-ehcache-v1/pom.xml
@@ -49,24 +49,4 @@
     </plugins>
   </build>
   
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>  
 </project>

--- a/management-ehcache-v2/pom.xml
+++ b/management-ehcache-v2/pom.xml
@@ -48,25 +48,5 @@
       </plugin>
     </plugins>
   </build>
-  
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>  
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>  
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>net.sf.ehcache</groupId>
     <artifactId>ehcache-parent</artifactId>
-    <version>2.25</version>
+    <version>2.27</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
     <sizeof-agent.version>1.0.1</sizeof-agent.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
-    <management-core.version>2.1.23</management-core.version>
+    <management-core.version>2.1.25</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>
-    <jetty.version>9.4.30.v20200611</jetty.version>
+    <jetty.version>9.4.35.v20201120</jetty.version>
     <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
     <hibernate-core.version>3.5.1-Final</hibernate-core.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -368,24 +368,45 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections-maven</artifactId>
-            <version>0.9.9-RC1</version>
-            <configuration>
-              <scanners>org.reflections.scanners.TypeAnnotationsScanner</scanners>
-              <destinations>${project.build.directory}/reflections.xml</destinations>
-              <tests>true</tests>
-              <parallel>true</parallel>
-            </configuration>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <version>1.12.1</version>
             <executions>
               <execution>
-                <goals>
-                  <goal>reflections</goal>
-                </goals>
                 <phase>process-test-classes</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <scripts>
+                    <script><![CDATA[
+                        new org.reflections.Reflections("net.sf.ehcache")
+                            .save("${project.build.outputDirectory}/reflections.xml")
+                    ]]></script>
+                  </scripts>
+                </configuration>
               </execution>
             </executions>
-          </plugin>       
+            <dependencies>
+              <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.9.12</version>
+              </dependency>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.17</version>
+                <scope>runtime</scope>
+              </dependency>
+              <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>2.1.3</version>
+              </dependency>
+
+            </dependencies>
+          </plugin>
           <plugin>
             <groupId>org.terracotta</groupId>
             <artifactId>maven-forge-plugin</artifactId>
@@ -462,25 +483,11 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <!-- minimal set to find the parent -->
   <repositories>
     <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
       <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
+      <url>https://repo.terracotta.org/maven2</url>
     </repository>
   </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
     <sizeof-agent.version>1.0.1</sizeof-agent.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
-    <management-core.version>2.1.25.2</management-core.version>
+    <management-core.version>2.1.25.3</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>
-    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jetty.version>9.4.39.v20210325</jetty.version>
     <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
     <hibernate-core.version>3.5.1-Final</hibernate-core.version>
     <commons-logging.version>1.2</commons-logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <sizeof-agent.version>1.0.1</sizeof-agent.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
-    <management-core.version>2.1.25</management-core.version>
+    <management-core.version>2.1.25.1</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
     <sizeof-agent.version>1.0.1</sizeof-agent.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
-    <management-core.version>2.1.25.1</management-core.version>
+    <management-core.version>2.1.25.2</management-core.version>
     <clustered-entity-management.version>0.11.1</clustered-entity-management.version>
     <statistics.version>1.0.5</statistics.version>
     <quartz.version>2.2.3</quartz.version>
-    <jetty.version>9.4.35.v20201120</jetty.version>
+    <jetty.version>9.4.38.v20210224</jetty.version>
     <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
     <hibernate-core.version>3.5.1-Final</hibernate-core.version>
     <commons-logging.version>1.2</commons-logging.version>
@@ -171,9 +171,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>javassist</groupId>
+        <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.4.GA</version>
+        <version>3.19.0-GA</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -272,36 +272,4 @@
     </profile>    
   </profiles>
 
-  <repositories> 
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>     
-    </repository>
-    <repository>
-      <id>jboss</id>
-      <name>JBoss Repository</name>
-      <url>https://repository.jboss.org/nexus/content/repositories/public/</url>    
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository> 
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>    
-  </pluginRepositories> 
 </project>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -81,9 +81,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.8.0.GA</version>
+      <version>3.19.0-GA</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -66,27 +66,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <profiles>
     <profile>
       <id>deploy-sonatype</id>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -17,52 +17,6 @@
     <module>bootstrap</module>
   </modules>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>  
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>      
-    </repository>
-  </repositories>
-  
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>    
-  </pluginRepositories>
-  
   <profiles>
     <profile>
       <id>deploy-sonatype</id>


### PR DESCRIPTION
2021-11-05T18:05:13.401064055+08:00 stderr F 05-Nov-2021 18:05:13.400 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [net.sf.ehcache.util.concurrent.Striped64.ThreadHashCode] (value [net.sf.ehcache.util.concurrent.Striped64$ThreadHashCode@76e4b567]) and a value of type [net.sf.ehcache.util.concurrent.Striped64.HashCode] (value [net.sf.ehcache.util.concurrent.Striped64$HashCode@16d82de2]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.401204419+08:00 stderr F 05-Nov-2021 18:05:13.401 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [net.sf.ehcache.util.concurrent.Striped64.ThreadHashCode] (value [net.sf.ehcache.util.concurrent.Striped64$ThreadHashCode@76e4b567]) and a value of type [net.sf.ehcache.util.concurrent.Striped64.HashCode] (value [net.sf.ehcache.util.concurrent.Striped64$HashCode@65cbb6d6]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.401294593+08:00 stderr F 05-Nov-2021 18:05:13.401 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [net.sf.ehcache.util.concurrent.Striped64.ThreadHashCode] (value [net.sf.ehcache.util.concurrent.Striped64$ThreadHashCode@76e4b567]) and a value of type [net.sf.ehcache.util.concurrent.Striped64.HashCode] (value [net.sf.ehcache.util.concurrent.Striped64$HashCode@465bb2a3]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.402847996+08:00 stderr F 05-Nov-2021 18:05:13.402 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@70aa4276]) and a value of type [io.netty.util.internal.InternalThreadLocalMap] (value [io.netty.util.internal.InternalThreadLocalMap@2f0ee8a9]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.402926647+08:00 stderr F 05-Nov-2021 18:05:13.402 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [net.sf.ehcache.util.concurrent.Striped64.ThreadHashCode] (value [net.sf.ehcache.util.concurrent.Striped64$ThreadHashCode@76e4b567]) and a value of type [net.sf.ehcache.util.concurrent.Striped64.HashCode] (value [net.sf.ehcache.util.concurrent.Striped64$HashCode@78ee6797]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.402978603+08:00 stderr F 05-Nov-2021 18:05:13.402 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@2e16608d]) and a value of type [org.apache.dubbo.common.threadlocal.InternalThreadLocalMap] (value [org.apache.dubbo.common.threadlocal.InternalThreadLocalMap@402b135a]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.403056097+08:00 stderr F 05-Nov-2021 18:05:13.403 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@70aa4276]) and a value of type [io.netty.util.internal.InternalThreadLocalMap] (value [io.netty.util.internal.InternalThreadLocalMap@5bfe6f56]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.403141191+08:00 stderr F 05-Nov-2021 18:05:13.403 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [net.sf.ehcache.util.concurrent.Striped64.ThreadHashCode] (value [net.sf.ehcache.util.concurrent.Striped64$ThreadHashCode@76e4b567]) and a value of type [net.sf.ehcache.util.concurrent.Striped64.HashCode] (value [net.sf.ehcache.util.concurrent.Striped64$HashCode@3ed9f20]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
2021-11-05T18:05:13.403233564+08:00 stderr F 05-Nov-2021 18:05:13.403 SEVERE [Thread-81] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [els] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@2e16608d]) and a value of type [org.apache.dubbo.common.threadlocal.InternalThreadLocalMap] (value [org.apache.dubbo.common.threadlocal.InternalThreadLocalMap@8348215]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.