### PR TITLE
fixes walking over internal JDK11 fields

### DIFF
--- a/ehcache-core/src/main/java/net/sf/ehcache/pool/sizeof/ObjectGraphWalker.java
+++ b/ehcache-core/src/main/java/net/sf/ehcache/pool/sizeof/ObjectGraphWalker.java
@@ -273,7 +273,12 @@ final class ObjectGraphWalker {
                         LOG.error("Security settings prevent Ehcache from accessing the subgraph beneath '{}'" +
                                 " - cache sizes may be underestimated as a result", field, e);
                         continue;
+                    } catch (RuntimeException e) {
+                        LOG.warn("The JVM is preventing Ehcache from accessing the subgraph beneath '{}'" +
+                                " - cache sizes may be underestimated as a result", field, e);
+                        continue;
                     }
+
                     fields.add(field);
                 }
             }


### PR DESCRIPTION
This is a backport of a fix developed in:

https://github.com/ehcache/sizeof/pull/61
https://github.com/ehcache/sizeof/issues/54
Original Author: @mprusakov

Also adds unit test for that issue.