### PR TITLE
TAB-8363 - For vulnerability issue upgrade jetty-server from 10.0.13 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   
   <properties>
-    <jetty.version>10.0.13</jetty.version>
+    <jetty.version>10.0.15</jetty.version>
     <thirdparty-bom.version>4.4.0-SNAPSHOT</thirdparty-bom.version>
     <terracotta-toolkit-api-internal.version>1.19</terracotta-toolkit-api-internal.version>
     <management-core.version>2.1.35-SNAPSHOT</management-core.version>
@@ -286,7 +286,7 @@
                   <scripts>
                     <script><![CDATA[
                         new org.reflections.Reflections("net.sf.ehcache")
-                            .save("${project.build.outputDirectory}/reflections.xml")
+                            .save(new File(project.build.outputDirectory, "reflections.xml").absolutePath)
                     ]]></script>
                   </scripts>
                 </configuration>


### PR DESCRIPTION
…to 10.0.15

1) For vulnerability issue upgrade jetty-server from 10.0.13 to 10.0.15. 

2) Fixed build error for running check-short test, so that save operation in script does not fail.